### PR TITLE
docs: Update repository URLs from huguesclouatre to clouatre

### DIFF
--- a/.github/PYPI_TRUSTED_PUBLISHING.md
+++ b/.github/PYPI_TRUSTED_PUBLISHING.md
@@ -40,7 +40,7 @@ Click "Add a new publisher" and fill in:
 
 ```
 Publisher: GitHub
-Repository owner: huguesclouatre
+Repository owner: clouatre
 Repository name: math-mcp-learning-server
 Workflow name: python-publish.yml
 Environment name: pypi
@@ -109,7 +109,7 @@ PyPI Package Index
 **Cause:** GitHub environment `pypi` not configured.
 
 **Solution:**
-- Verify environment exists: https://github.com/huguesclouatre/math-mcp-learning-server/settings/environments
+- Verify environment exists: https://github.com/clouatre/math-mcp-learning-server/settings/environments
 - Check workflow references correct environment name
 
 ## References

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This project maintains a **fast & minimal** philosophy while providing education
 ### **Development Setup**
 ```bash
 # Clone the repository
-git clone https://github.com/huguesclouatre/math-mcp-learning-server.git
+git clone https://github.com/clouatre/math-mcp-learning-server.git
 cd math-mcp-learning-server
 
 # Install dependencies and activate virtual environment
@@ -266,7 +266,7 @@ Once the release is published, GitHub Actions automatically:
 3. ✅ **Publishes to PyPI** - Using Trusted Publishing (no tokens!)
 
 #### **3. Monitor Progress**
-- Watch workflow: https://github.com/huguesclouatre/math-mcp-learning-server/actions
+- Watch workflow: https://github.com/clouatre/math-mcp-learning-server/actions
 - Check PyPI: https://pypi.org/project/math-mcp-learning-server/
 
 #### **4. Verify Release**

--- a/FUTURE_IMPROVEMENTS.md
+++ b/FUTURE_IMPROVEMENTS.md
@@ -282,7 +282,7 @@ uv pip install math-mcp-learning-server[dev]
 uv pip install math-mcp-learning-server[plotting,dev]
 
 # Development (local):
-git clone https://github.com/huguesclouatre/math-mcp-learning-server
+git clone https://github.com/clouatre/math-mcp-learning-server
 cd math-mcp-learning-server
 uv sync --all-extras
 uv run fastmcp dev src/math_mcp/server.py

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ math-mcp-learning-server/
 
 ```bash
 # Clone the repository
-git clone https://github.com/huguesclouatre/math-mcp-learning-server.git
+git clone https://github.com/clouatre/math-mcp-learning-server.git
 cd math-mcp-learning-server
 
 # Install dependencies (includes plotting support)

--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -35,7 +35,7 @@ This server includes a `fastmcp.json` configuration file for seamless cloud depl
 ### Deploy to FastMCP Cloud
 
 1. **Navigate to**: [FastMCP Cloud Dashboard](https://fastmcp.cloud)
-2. **Connect GitHub Repository**: `huguesclouatre/math-mcp-learning-server`
+2. **Connect GitHub Repository**: `clouatre/math-mcp-learning-server`
 3. **Deploy**: FastMCP Cloud auto-detects `fastmcp.json` configuration
 4. **Access via MCP Client**: Connect your MCP client to `https://math-mcp-learning.fastmcp.app/mcp`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.7.1"
+version = "0.7.2"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -30,15 +30,15 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/huguesclouatre/math-mcp-learning-server"
-Repository = "https://github.com/huguesclouatre/math-mcp-learning-server"
-Issues = "https://github.com/huguesclouatre/math-mcp-learning-server/issues"
-Documentation = "https://github.com/huguesclouatre/math-mcp-learning-server#readme"
-Contributing = "https://github.com/huguesclouatre/math-mcp-learning-server/blob/main/CONTRIBUTING.md"
-"Future Improvements" = "https://github.com/huguesclouatre/math-mcp-learning-server/blob/main/FUTURE_IMPROVEMENTS.md"
-Changelog = "https://github.com/huguesclouatre/math-mcp-learning-server/releases"
-"Code of Conduct" = "https://github.com/huguesclouatre/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md"
-License = "https://github.com/huguesclouatre/math-mcp-learning-server/blob/main/LICENSE"
+Homepage = "https://github.com/clouatre/math-mcp-learning-server"
+Repository = "https://github.com/clouatre/math-mcp-learning-server"
+Issues = "https://github.com/clouatre/math-mcp-learning-server/issues"
+Documentation = "https://github.com/clouatre/math-mcp-learning-server#readme"
+Contributing = "https://github.com/clouatre/math-mcp-learning-server/blob/main/CONTRIBUTING.md"
+"Future Improvements" = "https://github.com/clouatre/math-mcp-learning-server/blob/main/FUTURE_IMPROVEMENTS.md"
+Changelog = "https://github.com/clouatre/math-mcp-learning-server/releases"
+"Code of Conduct" = "https://github.com/clouatre/math-mcp-learning-server/blob/main/CODE_OF_CONDUCT.md"
+License = "https://github.com/clouatre/math-mcp-learning-server/blob/main/LICENSE"
 
 [project.scripts]
 math-mcp-learning-server = "math_mcp.server:main"


### PR DESCRIPTION
## Summary
Updates all repository references from `huguesclouatre` to `clouatre` following GitHub username change.

## Changes
- **pyproject.toml**: Version bump to 0.7.2, update all project URLs
- **README.md**: Update clone URL
- **CONTRIBUTING.md**: Update clone and workflow URLs  
- **FUTURE_IMPROVEMENTS.md**: Update clone URL
- **docs/CLOUD_DEPLOYMENT.md**: Update repository reference
- **.github/PYPI_TRUSTED_PUBLISHING.md**: Update repository owner and URLs

## Educational Impact
Maintains professional standards by keeping all documentation in sync with the new repository URL. GitHub redirects ensure backward compatibility for existing users.

## Testing
- ✅ All 67 tests passing
- ✅ Type checking clean (mypy)
- ✅ Linting clean (ruff)

## MCP Compliance
No changes to MCP server functionality - purely documentation updates.