### PR TITLE
revert: Use working math-mcp-learning cloud endpoint

### DIFF
--- a/FUTURE_IMPROVEMENTS.md
+++ b/FUTURE_IMPROVEMENTS.md
@@ -9,7 +9,7 @@ This project follows **FastMCP 2.0 best practices**:
 - **Optional features**: Defined in `[project.optional-dependencies]` for plotting, etc.
 - **Production**: Install via PyPI with optional groups: `uv pip install math-mcp-learning-server[plotting]`
 - **Development**: `uv sync --all-extras` for all optional dependencies
-- **Cloud deployment**: Automatic via FastMCP Cloud (https://math-learning.fastmcp.app/mcp)
+- **Cloud deployment**: Automatic via FastMCP Cloud (https://math-mcp-learning.fastmcp.app/mcp)
 
 ## 🔌 **MCP Client Requirement**
 
@@ -92,7 +92,7 @@ get_workspace()  # Shows all saved calculations
 - ✅ **Unified workspace file** (`~/.math-mcp/workspace.json`) across all transports
 
 #### **1.3 FastMCP Cloud Deployment ✅ COMPLETE**
-- ✅ **Cloud hosting at https://math-learning.fastmcp.app/mcp**
+- ✅ **Cloud hosting at https://math-mcp-learning.fastmcp.app/mcp**
 - ✅ **Automatic environment-based authentication** (OAuth, JWT via env vars)
 - ✅ **Production transport support** (SSE, HTTP)
 - ✅ **Zero-config deployment** from GitHub repository
@@ -290,7 +290,7 @@ uv run fastmcp dev src/math_mcp/server.py
 # Then connect via MCP client (Claude Desktop, Claude Code, OpenCode, etc.)
 
 # Cloud deployment:
-# Visit https://math-learning.fastmcp.app/mcp
+# Visit https://math-mcp-learning.fastmcp.app/mcp
 # Or deploy your own via FastMCP Cloud
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/math-mcp-learning-server.svg)](https://pypi.org/project/math-mcp-learning-server/)
 
-**Cloud hosted:** Connect any MCP client to [https://math-learning.fastmcp.app/mcp](https://math-learning.fastmcp.app/mcp) (MCP client required, no local server install needed)
-
-> **Note:** Cloud endpoint migrated from `math-mcp-learning` to `math-learning` (January 2025) following GitHub username change. Update your MCP client configuration if using the old endpoint.
+**Cloud hosted:** Connect any MCP client to [https://math-mcp-learning.fastmcp.app/mcp](https://math-mcp-learning.fastmcp.app/mcp) (MCP client required, no local server install needed)
 
 A persistent quantitative workspace built as a Model Context Protocol (MCP) server. This project demonstrates enterprise-grade patterns for MCP development, featuring cross-session state persistence - a unique capability that most LLMs cannot achieve natively.
 
@@ -38,7 +36,7 @@ Connect your MCP client to the hosted server - no local installation required!
   "mcpServers": {
     "math-cloud": {
       "transport": "http",
-      "url": "https://math-learning.fastmcp.app/mcp"
+      "url": "https://math-mcp-learning.fastmcp.app/mcp"
     }
   }
 }
@@ -46,7 +44,7 @@ Connect your MCP client to the hosted server - no local installation required!
 
 **Claude Code:**
 ```bash
-claude mcp add math-cloud https://math-learning.fastmcp.app/mcp
+claude mcp add math-cloud https://math-mcp-learning.fastmcp.app/mcp
 ```
 
 ### Option 2: Run Locally

--- a/docs/CLOUD_DEPLOYMENT.md
+++ b/docs/CLOUD_DEPLOYMENT.md
@@ -1,7 +1,5 @@
 # Cloud Deployment Guide
 
-> **Endpoint Migration (January 2025):** Cloud endpoint changed from `math-mcp-learning.fastmcp.app` to `math-learning.fastmcp.app` following GitHub username migration. Update your client configurations.
-
 ## FastMCP Cloud Deployment
 
 Deploy this server to [FastMCP Cloud](https://fastmcp.cloud) for hosted, production-ready access without local setup.
@@ -39,7 +37,7 @@ This server includes a `fastmcp.json` configuration file for seamless cloud depl
 1. **Navigate to**: [FastMCP Cloud Dashboard](https://fastmcp.cloud)
 2. **Connect GitHub Repository**: `clouatre/math-mcp-learning-server`
 3. **Deploy**: FastMCP Cloud auto-detects `fastmcp.json` configuration
-4. **Access via MCP Client**: Connect your MCP client to `https://math-learning.fastmcp.app/mcp`
+4. **Access via MCP Client**: Connect your MCP client to `https://math-mcp-learning.fastmcp.app/mcp`
 
 ### Cloud Storage Considerations
 


### PR DESCRIPTION
Reverts cloud endpoint URLs back to the working `math-mcp-learning.fastmcp.app` deployment.

## Reason
The `math-learning` deployment encountered configuration issues that couldn't be resolved. The original `math-mcp-learning` deployment works perfectly and is already updated to pull from `clouatre/math-mcp-learning-server`.

## Changes
- Revert all documentation to use `math-mcp-learning.fastmcp.app/mcp`
- Remove migration notices added in PR #43
- Keep version at 0.7.3 for release

## Testing
- Original endpoint confirmed working and serving latest code