### PR TITLE
[Fix] Resolve workspace persistence regression (v0.7.4)

### DIFF
--- a/fastmcp.json
+++ b/fastmcp.json
@@ -9,7 +9,6 @@
     "type": "uv",
     "python": ">=3.11",
     "dependencies": [
-      ".",
       "fastmcp>=2.0.0",
       "pydantic>=2.11.9",
       "matplotlib>=3.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.7.3"
+version = "0.7.4"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Summary
This PR fixes a critical workspace persistence bug introduced in v0.7.2-0.7.3 that prevented  and  from sharing state across sessions.

## Root Cause Analysis
Versions 0.7.2 and 0.7.3 introduced **dual import paths** for math_mcp modules:
- **v0.7.2**: Added `"."` to fastmcp.json dependencies (package self-import)
- **v0.7.3**: Added `PYTHONPATH=src` environment variable

Having both active created two ways to import math_mcp modules:
1. Via package installation: `from math_mcp import workspace`
2. Via PYTHONPATH: `from math_mcp import workspace` (different module instance)

## Impact
The lazy imports in server.py tool functions resolved to **different module instances** each time, breaking the WorkspaceManager singleton pattern:
- `save_calculation` used WorkspaceManager instance A
- `load_variable` used WorkspaceManager instance B
- Result: Saved calculations were never found by load operations

## Fix Applied
Removed `"."` from fastmcp.json dependencies array to restore single import resolution like v0.7.1:
- **Before**: Package install + PYTHONPATH (dual paths)
- **After**: PYTHONPATH only (single path)

## Educational Impact
Demonstrates critical MCP development lesson:
- Import path consistency is essential for singleton patterns
- Cloud deployment environments need careful dependency management
- Testing across versions catches subtle integration bugs

## Testing
- All 67 tests pass: `uv run pytest tests/ -v`
- Type checking clean: `uv run mypy src/`
- Linting passed: `uv run ruff check`
- Workspace persistence manually verified

## MCP Compliance
- FastMCP 2.0 pattern: Single source of truth for module imports
- Singleton pattern preserved: WorkspaceManager instance consistency
- Cloud deployment ready: Correct environment configuration

## Version Update
- Version bumped to **0.7.4** (PATCH release - bug fix)
- No breaking changes
- Backwards compatible

## Related Issues
Fixes workspace persistence regression introduced in #44