### PR TITLE
[Chore] Remove redundant requirements.txt (v0.7.5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "math-mcp-learning-server"
-version = "0.7.4"
+version = "0.7.5"
 description = "Production-ready educational MCP server with enhanced visualizations and persistent workspace - Complete learning guide demonstrating FastMCP 2.0 best practices for Model Context Protocol development"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-# Core dependencies for FastMCP Cloud deployment (must match pyproject.toml)
-fastmcp>=2.0.0
-matplotlib>=3.10.6
-numpy>=2.3.3
-pydantic>=2.11.9

--- a/uv.lock
+++ b/uv.lock
@@ -682,7 +682,7 @@ wheels = [
 
 [[package]]
 name = "math-mcp-learning-server"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary
Removes the unused `requirements.txt` file that is redundant with `fastmcp.json` and `pyproject.toml`.

## Changes
- Removed `requirements.txt` (not needed for FastMCP Cloud)
- Updated version to 0.7.5
- Dependencies are managed via:
  - `fastmcp.json` for FastMCP Cloud deployment
  - `pyproject.toml` for local development with uv

## Testing
- ✅ All 67 tests passing
- ✅ Type checking clean (mypy)
- ✅ Linting passed (ruff)

## Rationale
The `requirements.txt` file was:
- Not used by FastMCP Cloud (confirmed by user)
- Out of sync with `fastmcp.json` versions
- Redundant with modern uv/pyproject.toml workflow

This cleanup simplifies dependency management to two clear sources:
1. `fastmcp.json` for cloud deployment
2. `pyproject.toml` for local development